### PR TITLE
removed redundant variable definition

### DIFF
--- a/src/main/java/com/sieadev/allthebasics/commands/timer.java
+++ b/src/main/java/com/sieadev/allthebasics/commands/timer.java
@@ -73,7 +73,7 @@ Implements the /timer start/stop command
     private void updateActionBar(Player player) {
         if (timerRunning) {
             long currentTime = System.currentTimeMillis();
-            long elapsedTime = (currentTime - startTime) / 1000;
+            elapsedTime = (currentTime - startTime) / 1000;
             player.sendTitle("" , "§cTimer: " + elapsedTime + " §cseconds");
         }
     }


### PR DESCRIPTION
elapsedTime was defined gloabally and in the scope of updateActionBar, which causes errors.